### PR TITLE
Flag accessor

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,13 +22,13 @@ import sys
 #
 import obsarray
 
-sys.path.insert(0, os.path.abspath('..'))
+sys.path.insert(0, os.path.abspath(".."))
 
 project_title = "obsarray".replace("_", " ").title()
 
 # -- General configuration ---------------------------------------------
 
-latex_toplevel_sectioning = 'section'
+latex_toplevel_sectioning = "section"
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
@@ -41,22 +41,22 @@ default_role = "code"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 # CFAB added napolean to support google-style docstrings
 extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.viewcode',
-    'sphinx.ext.napoleon',
+    "sphinx.ext.autodoc",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.napoleon",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
 project = project_title
@@ -82,10 +82,10 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
@@ -96,7 +96,7 @@ todo_include_todos = False
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Theme options are theme-specific and customize the look and feel of a
 # theme further.  For a list of options available for each theme, see the
@@ -107,13 +107,13 @@ html_theme = 'sphinx_rtd_theme'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 
 # -- Options for HTMLHelp output ---------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'obsarraydoc'
+htmlhelp_basename = "obsarraydoc"
 
 
 # -- Options for LaTeX output ------------------------------------------
@@ -122,15 +122,12 @@ latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',
-
     # The font size ('10pt', '11pt' or '12pt').
     #
     # 'pointsize': '10pt',
-
     # Additional stuff for the LaTeX preamble.
     #
     # 'preamble': '',
-
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',
@@ -140,9 +137,13 @@ latex_elements = {
 # (source start file, target name, title, author, documentclass
 # [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'user_manual.tex',
-     '{} Documentation'.format(project_title),
-     'Sam Hunt', 'manual'),
+    (
+        master_doc,
+        "user_manual.tex",
+        "{} Documentation".format(project_title),
+        "Sam Hunt",
+        "manual",
+    ),
 ]
 
 
@@ -150,11 +151,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    (master_doc, 'obsarray',
-     'obsarray Documentation',
-     [author], 1)
-]
+man_pages = [(master_doc, "obsarray", "obsarray Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output ----------------------------------------
@@ -163,12 +160,15 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'obsarray',
-     'obsarray Documentation',
-     author,
-     'obsarray',
-     'Propagating UNcertainties in PYthon',
-     'Miscellaneous'),
+    (
+        master_doc,
+        "obsarray",
+        "obsarray Documentation",
+        author,
+        "obsarray",
+        "Propagating UNcertainties in PYthon",
+        "Miscellaneous",
+    ),
 ]
 
 """

--- a/docs/content/user/flag_accessor.rst
+++ b/docs/content/user/flag_accessor.rst
@@ -1,0 +1,35 @@
+Interfacing with Flag Information
++++++++++++++++++++++++++++++++++
+
+obsarray enables users to define, store and interface with flag variables in :py:class:`xarray.Dataset`'s following the `CF Convention <https://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/cf-conventions.html#flags>`_ metadata standard.
+
+To access the information from a particular flag variable, use the dataset's ``flag`` accessor as follows,
+
+.. code-block:: python
+
+    import xarray as xr
+    import obsarray
+
+    ds = xr.open_dataset("measurement_data.nc")
+    print(ds.flag["flag_var"])
+
+This lists the flags for that variable. To access the flag values for a particular flag variable,
+
+.. code-block:: python
+
+    ds.flag["flag_var"]["flag_1"].value         # get flag mask
+    ds.flag["flag_var"]["flag_1"][:, 0] = True  # set flag mask values
+
+
+
+You can add a flag variable in a similar way to adding a new variable to a dataset,
+
+.. code-block:: python
+
+    ds.flag["new_flag_var"] = (["dims"], {"flag_meanings": ["f1", "f2"]})
+
+or add a new flag to an existing flag variable,
+
+.. code-block:: python
+
+    ds.flag["new_flag_var"]["f3"] = False

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,7 @@ obsarray is under active development. It is beta software.
     :caption: User Guide
 
     content/user/unc_accessor
+    content/user/flag_accessor
     content/user/templater
 
 .. toctree::

--- a/obsarray/__init__.py
+++ b/obsarray/__init__.py
@@ -4,7 +4,7 @@ __author__ = "Sam Hunt <sam.hunt@npl.co.uk>"
 __all__ = []
 
 from ._version import get_versions
-from obsarray import unc_accessor
+from obsarray import unc_accessor, flag_accessor
 from obsarray.err_corr import err_corr_forms
 from obsarray.templater.template_util import create_ds
 from obsarray.templater.dstemplater import DSTemplater

--- a/obsarray/flag_accessor.py
+++ b/obsarray/flag_accessor.py
@@ -1,0 +1,25 @@
+"""unc_accessor - xarray extensions with accessor objects for uncertainty handling"""
+
+import xarray as xr
+
+
+__author__ = "Sam Hunt <sam.hunt@npl.co.uk>"
+__all__ = []
+
+
+@xr.register_dataset_accessor("flag")
+class FlagAccessor(object):
+    """
+    ``xarray.Dataset`` accesssor object for handling dataset variable flags
+
+    :param xarray_obj: xarray dataset
+    """
+
+    def __init__(self, xarray_obj: xr.Dataset):
+
+        # Initialise attributes
+        self._obj = xarray_obj
+
+
+if __name__ == "__main__":
+    pass

--- a/obsarray/flag_accessor.py
+++ b/obsarray/flag_accessor.py
@@ -465,8 +465,10 @@ class DatasetUtil2:
             data_type,
             dim_names=dim_names,
             attributes=attributes,
-            fill_value=0,
         )
+
+        #initialise flags to zero (instead of fillvalue)
+        variable.values=0*variable.values
 
         # add flag attributes
         variable.attrs["flag_meanings"] = (

--- a/obsarray/flag_accessor.py
+++ b/obsarray/flag_accessor.py
@@ -132,11 +132,23 @@ class Flag:
         :return: flag variable flag value
         """
 
-        value = DatasetUtil.create_variable(
-            list(self._obj[self._flag_var_name][self._sli].shape),
-            bool,
-            dim_names=list(self._obj[self._flag_var_name].dims),
+        flag_meanings, flag_masks = DatasetUtil.unpack_flag_attrs(
+            self._obj[self._flag_var_name].attrs
         )
+
+        flag_bit = flag_meanings.index(self._flag_meaning)
+        flag_mask = flag_masks[flag_bit]
+
+        value = xr.DataArray(
+            np.zeros(self._obj[self._flag_var_name][self._sli].shape, dtype=bool),
+            dims=list(self._obj[self._flag_var_name][self._sli].dims),
+        )
+
+        value.values[:] = (
+            self._obj[self._flag_var_name][self._sli] & flag_mask
+        ).astype(bool)
+
+        return value
 
 
 class FlagVariable:

--- a/obsarray/flag_accessor.py
+++ b/obsarray/flag_accessor.py
@@ -1,4 +1,4 @@
-"""unc_accessor - xarray extensions with accessor objects for uncertainty handling"""
+"""flag_accessor - xarray extensions with accessor objects for flag handling"""
 
 import xarray as xr
 from typing import List, Optional
@@ -125,9 +125,9 @@ class FlagVariable:
 
     def __len__(self) -> int:
         """
-        Returns number of variable uncertainties
+        Returns number of flag variable flags
 
-        :returns: number of variable uncertainties
+        :returns: number of flag variable flags
         """
         return len(self.keys())
 
@@ -139,12 +139,12 @@ class FlagVariable:
 
     def __next__(self) -> Flag:
         """
-        Returns ith variable uncertainty
+        Returns ith flag in flag variable
 
-        :return: uncertainty variable
+        :return: flag variable flag
         """
 
-        # Iterate through uncertainty comp
+        # Iterate through flag variable flags
         if self.i < len(self.keys()):
             self.i += 1  # Update counter
             return self[self.keys()[self.i - 1]]
@@ -154,9 +154,9 @@ class FlagVariable:
 
     def keys(self) -> List[str]:
         """
-        Returns uncertainty variable names
+        Returns flag variable flag names
 
-        :return: uncertainty variable names
+        :return: flag variable flag names
         """
         return self._obj[self._flag_var_name].attrs["flag_meanings"]
 
@@ -173,6 +173,16 @@ class FlagAccessor(object):
 
         # Initialise attributes
         self._obj = xarray_obj
+
+    def __str__(self) -> str:
+        """Custom __str__"""
+
+        string = "<{}>\nDataset Flags:\n".format(self.__class__.__name__)
+
+        for var_name in self.keys():
+            string += "* {}\n".format(self[var_name].__repr__())
+
+        return string
 
     def __repr__(self) -> str:
         """Custom  __repr__"""
@@ -200,28 +210,14 @@ class FlagAccessor(object):
         self.i = 0  # Define counter
         return self
 
-    def __str__(self) -> str:
-        """Custom __str__"""
-
-        string = "<{}>\nDataset Flags:\n".format(self.__class__.__name__)
-
-        for var_name in self.keys():
-            string += "* {}\n".format(self[var_name].__repr__())
-
-        return string
-
-    def __repr__(self) -> str:
-        """Custom  __repr__"""
-        return str(self)
-
     def __next__(self):
         """
-        Returns ith data variable
+        Returns ith flag variable
 
-        :return: ith data variable
+        :return: ith flag variable
         """
 
-        # Iterate through obs variables
+        # Iterate through flag variables
         if self.i < len(self.keys()):
             self.i += 1  # Update counter
             return self[self.keys()[self.i - 1]]
@@ -231,9 +227,9 @@ class FlagAccessor(object):
 
     def keys(self):
         """
-        Returns data variable names (i.e., non-flag variables)
+        Returns flag variable names
 
-        :return: data variable names
+        :return: flag variable names
         """
 
         return list(self._obj.flag.flag_vars.keys())
@@ -267,9 +263,9 @@ class FlagAccessor(object):
 
     def _is_data_var(self, var_name: str) -> bool:
         """
-        Returns true if named dataset variable is an observation variable
+        Returns true if named dataset variable is an data variable (i.e. not a flag variable)
 
-        :return: observation variable flag
+        :return: data variable bool
         """
 
         if not self._is_flag_var(var_name):
@@ -278,63 +274,14 @@ class FlagAccessor(object):
 
     def _is_flag_var(self, var_name: str) -> bool:
         """
-        Returns true if named dataset variable is an uncertainty variable
+        Returns true if named dataset variable is an flag variable
 
-        :return: uncertainty variable flag
+        :return: flag variable bool
         """
 
         if "flag_meanings" in self._obj[var_name].attrs:
             return True
         return False
-
-    def __str__(self):
-        """Custom __str__"""
-        return "<{}>\nVariable Uncertainties: '{}'\n{}".format(
-            self.__class__.__name__,
-            self._var_name,
-            self._obj.unc._var_unc_vars(self._var_name).__repr__(),
-        )
-
-    def __repr__(self):
-        """Custom  __repr__"""
-        return str(self)
-
-    def __len__(self) -> int:
-        """
-        Returns number of variable uncertainties
-
-        :returns: number of variable uncertainties
-        """
-        return len(self._obj.unc._var_unc_var_names(self._var_name))
-
-    def __iter__(self):
-        """Custom  __iter__"""
-
-        self.i = 0  # Define counter
-        return self
-
-    def __next__(self) -> Flag:
-        """
-        Returns ith variable uncertainty
-
-        :return: uncertainty variable
-        """
-
-        # Iterate through uncertainty comp
-        if self.i < len(self.keys()):
-            self.i += 1  # Update counter
-            return self[self.keys()[self.i - 1]]
-
-        else:
-            raise StopIteration
-
-    def keys(self) -> List[str]:
-        """
-        Returns uncertainty variable names
-
-        :return: uncertainty variable names
-        """
-        return self._obj.unc._var_unc_var_names(self._var_name)
 
 
 if __name__ == "__main__":

--- a/obsarray/flag_accessor.py
+++ b/obsarray/flag_accessor.py
@@ -7,6 +7,21 @@ __author__ = "Sam Hunt <sam.hunt@npl.co.uk>"
 __all__ = []
 
 
+class FlagVariable:
+    """
+    Interface for handling ``xarray.Dataset`` flag variables
+
+    :param xarray_obj: dataset
+    :param flag_var_name: name of flag variable
+    """
+
+    def __init__(self, xarray_obj: xr.Dataset, flag_var_name: str):
+
+        # Initialise attributes
+        self._obj = xarray_obj
+        self._flag_var_name = flag_var_name
+
+
 @xr.register_dataset_accessor("flag")
 class FlagAccessor(object):
     """
@@ -20,6 +35,439 @@ class FlagAccessor(object):
         # Initialise attributes
         self._obj = xarray_obj
 
+    def __repr__(self) -> str:
+        """Custom  __repr__"""
+        return str(self)
+
+    def __getitem__(self, var_name: str) -> FlagVariable:
+        """Custom  __repr__"""
+        return FlagVariable(self._obj, var_name)
+
+    def __len__(self):
+        """
+        Returns number of flag variables
+
+        :return: number of flag variables
+        """
+
+        return len(self.keys())
+
+    def __iter__(self) -> "FlagAccessor":
+        """
+        Initialises iterator
+
+        :return: self
+        """
+        self.i = 0  # Define counter
+        return self
+
+    def __str__(self) -> str:
+        """Custom __str__"""
+
+        string = "<{}>\nDataset Flags:\n".format(self.__class__.__name__)
+
+        for var_name in self.keys():
+            string += "* {}\n".format(self[var_name].__repr__())
+
+        return string
+
+    def __repr__(self) -> str:
+        """Custom  __repr__"""
+        return str(self)
+
+    def __next__(self):
+        """
+        Returns ith data variable
+
+        :return: ith data variable
+        """
+
+        # Iterate through obs variables
+        if self.i < len(self.keys()):
+            self.i += 1  # Update counter
+            return self[self.keys()[self.i - 1]]
+
+        else:
+            raise StopIteration
+
+    def keys(self):
+        """
+        Returns data variable names (i.e., non-flag variables)
+
+        :return: data variable names
+        """
+
+        return list(self._obj.flag.flag_vars.keys())
+
+    @property
+    def data_vars(self) -> xr.core.dataset.DataVariables:
+        """
+        Returns dataset data variables (defined as dataset variables that are not themselves flags)
+
+        :return: data variables
+        """
+        data_var_names = []
+        for var_name in self._obj.variables:
+            if self._is_data_var(var_name):
+                data_var_names.append(var_name)
+        return self._obj[data_var_names].data_vars
+
+    @property
+    def flag_vars(self) -> xr.core.dataset.DataVariables:
+        """
+        Returns dataset flag variables (defined as flags associated with data variables)
+
+        :return: flag variables
+        """
+        flag_var_names = []
+        for var_name in self._obj.variables:
+            if self._is_flag_var(var_name):
+                flag_var_names.append(var_name)
+
+        return self._obj[list(flag_var_names)].data_vars
+
+    def _is_data_var(self, var_name: str) -> bool:
+        """
+        Returns true if named dataset variable is an observation variable
+
+        :return: observation variable flag
+        """
+
+        if not self._is_flag_var(var_name):
+            return True
+        return False
+
+    def _is_flag_var(self, var_name: str) -> bool:
+        """
+        Returns true if named dataset variable is an uncertainty variable
+
+        :return: uncertainty variable flag
+        """
+
+        if "flag_meanings" in self._obj[var_name].attrs:
+            return True
+        return False
+
 
 if __name__ == "__main__":
     pass
+
+
+class DatasetUtil:
+    @staticmethod
+    def create_flags_variable(dim_sizes, meanings, dim_names=None, attributes=None):
+        """
+        Return default empty 1d xarray flag Variable
+
+        :type dim_sizes: list
+        :param dim_sizes: dimension sizes as ints, i.e. [dim1_size, dim2_size, dim3_size] (e.g. [2,3,5])
+
+        :type attributes: dict
+        :param attributes: (optional) dictionary of variable attributes, e.g. standard_name
+
+        :type dim_names: list
+        :param dim_names: (optional) dimension names as strings, i.e. ["dim1_name", "dim2_name", "dim3_size"]
+
+        :return: Default empty flag vector variable
+        :rtype: xarray.Variable
+        """
+
+        n_masks = len(meanings)
+
+        data_type = DatasetUtil.return_flags_dtype(n_masks)
+
+        variable = DatasetUtil.create_variable(
+            dim_sizes,
+            data_type,
+            dim_names=dim_names,
+            attributes=attributes,
+            fill_value=0,
+        )
+
+        # add flag attributes
+        variable.attrs["flag_meanings"] = (
+            str(meanings)[1:-1].replace("'", "").replace(",", "")
+        )
+        variable.attrs["flag_masks"] = str([2 ** i for i in range(0, n_masks)])[1:-1]
+
+        # todo - make sure flags can't have units
+
+        return variable
+
+    @staticmethod
+    def return_flags_dtype(n_masks):
+        """
+        Return required flags array data type
+
+        :type n_masks: int
+        :param n_masks: number of masks required in flag array
+
+        :return: data type
+        :rtype: dtype
+        """
+
+        if n_masks <= 8:
+            return np.int8
+        elif n_masks <= 16:
+            return np.int16
+        elif n_masks <= 32:
+            return np.int32
+        else:
+            return np.int64
+
+    @staticmethod
+    def add_encoding(
+        variable, dtype, scale_factor=1.0, offset=0.0, fill_value=None, chunksizes=None
+    ):
+        """
+        Add encoding to xarray Variable to apply when writing netCDF files
+
+        :type variable: xarray.Variable
+        :param variable: data variable
+
+        :type dtype: type
+        :param dtype: numpy data type
+
+        :type scale_factor: float
+        :param scale_factor: variable scale factor
+
+        :type offset: float
+        :param offset: variable offset value
+
+        :type fill_value: int/float
+        :param fill_value: (optional) fill value
+
+        :type chunksizes: float
+        :param chunksizes: (optional) chucksizes
+        """
+
+        # todo - make sure flags can't have encoding added
+
+        encoding_dict = {
+            "dtype": dtype,
+            "scale_factor": scale_factor,
+            "add_offset": offset,
+        }
+
+        if chunksizes is not None:
+            encoding_dict.update({"chunksizes": chunksizes})
+
+        if fill_value is not None:
+            encoding_dict.update({"_FillValue": fill_value})
+
+        variable.encoding = encoding_dict
+
+    @staticmethod
+    def get_default_fill_value(dtype):
+        """
+        Returns default fill_value for given data type
+
+        :type dtype: type
+        :param dtype: numpy dtype
+
+        :return: CF-conforming fill value
+        :rtype: fill_value
+        """
+
+        if dtype == np.int8:
+            return np.int8(-129)
+        if dtype == np.uint8:
+            return np.uint8(-1)
+        elif dtype == np.int16:
+            return np.int16(-32769)
+        elif dtype == np.uint16:
+            return np.uint16(-1)
+        elif dtype == np.int32:
+            return np.int32(-2147483649)
+        elif dtype == np.uint32:
+            return np.uint32(-1)
+        elif dtype == np.int64:
+            return np.int64(-9223372036854775808)
+        elif dtype == np.float32:
+            return np.float32(9.96921e36)
+        elif dtype == np.float64:
+            return np.float64(9.969209968386869e36)
+
+    @staticmethod
+    def _get_flag_encoding(da):
+        """
+        Returns flag encoding for flag type data array
+        :type da: xarray.DataArray
+        :param da: data array
+        :return: flag meanings
+        :rtype: list
+        :return: flag masks
+        :rtype: list
+        """
+
+        try:
+            flag_meanings = da.attrs["flag_meanings"].split()
+            flag_masks = [int(fm) for fm in da.attrs["flag_masks"].split(",")]
+        except KeyError:
+            raise KeyError(da.name + " not a flag variable")
+
+        return flag_meanings, flag_masks
+
+    @staticmethod
+    def unpack_flags(da):
+        """
+        Breaks down flag data array into dataset of boolean masks for each flag
+        :type da: xarray.DataArray
+        :param da: dataset
+        :return: flag masks
+        :rtype: xarray.Dataset
+        """
+
+        flag_meanings, flag_masks = DatasetUtil._get_flag_encoding(da)
+
+        ds = Dataset()
+        for flag_meaning, flag_mask in zip(flag_meanings, flag_masks):
+            ds[flag_meaning] = DatasetUtil.create_variable(
+                list(da.shape), bool, dim_names=list(da.dims)
+            )
+            ds[flag_meaning] = (da & flag_mask).astype(bool)
+
+        return ds
+
+    @staticmethod
+    def get_flags_mask_or(da, flags=None):
+        """
+        Returns boolean mask for set of flags, defined as logical or of flags
+
+        :type da: xarray.DataArray
+        :param da: dataset
+
+        :type flags: list
+        :param flags: list of flags (if unset all data flags selected)
+
+        :return: flag masks
+        :rtype: numpy.ndarray
+        """
+
+        flags_ds = DatasetUtil.unpack_flags(da)
+
+        flags = flags if flags is not None else flags_ds.variables
+        mask_flags = [flags_ds[flag].values for flag in flags]
+
+        return np.logical_or.reduce(mask_flags)
+
+    @staticmethod
+    def get_flags_mask_and(da, flags=None):
+        """
+        Returns boolean mask for set of flags, defined as logical and of flags
+
+        :type da: xarray.DataArray
+        :param da: dataset
+
+        :type flags: list
+        :param flags: list of flags (if unset all data flags selected)
+
+        :return: flag masks
+        :rtype: numpy.ndarray
+        """
+
+        flags_ds = DatasetUtil.unpack_flags(da)
+
+        flags = flags if flags is not None else flags_ds.variables
+        mask_flags = [flags_ds[flag].values for flag in flags]
+
+        return np.logical_and.reduce(mask_flags)
+
+    @staticmethod
+    def set_flag(da, flag_name, error_if_set=False):
+        """
+        Sets named flag for elements in data array
+        :type da: xarray.DataArray
+        :param da: dataset
+        :type flag_name: str
+        :param flag_name: name of flag to set
+        :type error_if_set: bool
+        :param error_if_set: raises error if chosen flag is already set for any element
+        """
+
+        set_flags = DatasetUtil.unpack_flags(da)[flag_name]
+
+        if np.any(set_flags == True) and error_if_set:
+            raise ValueError(
+                "Flag " + flag_name + " already set for variable " + da.name
+            )
+
+        # Find flag mask
+        flag_meanings, flag_masks = DatasetUtil._get_flag_encoding(da)
+        flag_bit = flag_meanings.index(flag_name)
+        flag_mask = flag_masks[flag_bit]
+
+        da.values = da.values | flag_mask
+
+        return da
+
+    @staticmethod
+    def unset_flag(da, flag_name, error_if_unset=False):
+        """
+        Unsets named flag for specified index of dataset variable
+        :type da: xarray.DataArray
+        :param da: data array
+        :type flag_name: str
+        :param flag_name: name of flag to unset
+        :type error_if_unset: bool
+        :param error_if_unset: raises error if chosen flag is already set at specified index
+        """
+
+        set_flags = DatasetUtil.unpack_flags(da)[flag_name]
+
+        if np.any(set_flags == False) and error_if_unset:
+            raise ValueError(
+                "Flag " + flag_name + " already set for variable " + da.name
+            )
+
+        # Find flag mask
+        flag_meanings, flag_masks = DatasetUtil._get_flag_encoding(da)
+        flag_bit = flag_meanings.index(flag_name)
+        flag_mask = flag_masks[flag_bit]
+
+        da.values = da.values & ~flag_mask
+
+        return da
+
+    @staticmethod
+    def get_set_flags(da):
+        """
+        Return list of set flags for single element data array
+        :type da: xarray.DataArray
+        :param da: single element data array
+        :return: set flags
+        :rtype: list
+        """
+
+        if da.shape != ():
+            raise ValueError("Must pass single element data array")
+
+        flag_meanings, flag_masks = DatasetUtil._get_flag_encoding(da)
+
+        set_flags = []
+        for flag_meaning, flag_mask in zip(flag_meanings, flag_masks):
+            if da & flag_mask:
+                set_flags.append(flag_meaning)
+
+        return set_flags
+
+    @staticmethod
+    def check_flag_set(da, flag_name):
+        """
+        Returns if flag for single element data array
+        :type da: xarray.DataArray
+        :param da: single element data array
+        :type flag_name: str
+        :param flag_name: name of flag to set
+        :return: set flags
+        :rtype: list
+        """
+
+        if da.shape != ():
+            raise ValueError("Must pass single element data array")
+
+        set_flags = DatasetUtil.get_set_flags(da)
+
+        if flag_name in set_flags:
+            return True
+        return False

--- a/obsarray/flag_accessor.py
+++ b/obsarray/flag_accessor.py
@@ -155,6 +155,20 @@ class FlagVariable:
 
         self[flag_meaning][:] = flag_value
 
+    def __delitem__(self, flag_meaning):
+        """
+        Removes defined flag variable flag
+
+        :param flag_meaning: flag meaning name
+        """
+
+        self[flag_meaning][:] = False
+
+        self._obj[self._flag_var_name].attrs = DatasetUtil.rm_flag_meaning_from_attrs(
+            self._obj[self._flag_var_name].attrs,
+            flag_meaning,
+        )
+
     def __str__(self):
         """Custom __str__"""
         return "<{}>\nFlagVariable: '{}'\n{}".format(

--- a/obsarray/templater/dataset_util.py
+++ b/obsarray/templater/dataset_util.py
@@ -355,7 +355,7 @@ class DatasetUtil:
         return updated_attrs
 
     @staticmethod
-    def rm_flag_meaning_to_attrs(attrs: dict, flag_meaning: str) -> dict:
+    def rm_flag_meaning_from_attrs(attrs: dict, flag_meaning: str) -> dict:
         """
         Remove flag meaning from flag variable attributes
 

--- a/obsarray/templater/dataset_util.py
+++ b/obsarray/templater/dataset_util.py
@@ -256,9 +256,11 @@ class DatasetUtil:
             dim_sizes,
             data_type,
             dim_names=dim_names,
-            fill_value=0,
             attributes=attributes,
         )
+
+        #initialise flags to zero (instead of fillvalue)
+        variable.values=0*variable.values
 
         # add flag attributes
         variable.attrs.update(DatasetUtil.pack_flag_attrs(meanings))

--- a/obsarray/templater/dataset_util.py
+++ b/obsarray/templater/dataset_util.py
@@ -268,11 +268,14 @@ class DatasetUtil:
         return variable
 
     @staticmethod
-    def pack_flag_attrs(flag_meanings: List[str]) -> dict:
+    def pack_flag_attrs(
+        flag_meanings: List[str], flag_masks: Optional[list] = None
+    ) -> dict:
         """
         Derive flag related dataset attributes
 
         :param flag_meanings: flag meanings
+        :param flag_masks: pre-defined flag masks, generated if not provided
         :return: set of derived flag related attributes
         """
 
@@ -284,7 +287,10 @@ class DatasetUtil:
             str(flag_meanings)[1:-1].replace("'", "").replace(",", "")
         )
 
-        flag_attrs["flag_masks"] = str([2 ** i for i in range(0, n_masks)])[1:-1]
+        if flag_masks is None:
+            flag_masks = [2 ** i for i in range(0, n_masks)]
+
+        flag_attrs["flag_masks"] = str(flag_masks)[1:-1]
 
         return flag_attrs
 
@@ -345,6 +351,33 @@ class DatasetUtil:
             if "flag_masks" in updated_attrs
             else str(flag_mask)
         )
+
+        return updated_attrs
+
+    @staticmethod
+    def rm_flag_meaning_to_attrs(attrs: dict, flag_meaning: str) -> dict:
+        """
+        Remove flag meaning from flag variable attributes
+
+        :param attrs: flag variable attributes
+        :param flag_meaning: new flag name
+
+        :return: updated variable attributes
+        """
+
+        updated_attrs = deepcopy(attrs)
+
+        flag_meanings, flag_masks = DatasetUtil.unpack_flag_attrs(attrs)
+
+        if flag_meaning in flag_meanings:
+            i_meaning = flag_meanings.index(flag_meaning)
+        else:
+            raise ValueError("no flag " + flag_meaning)
+
+        del flag_meanings[i_meaning]
+        del flag_masks[i_meaning]
+
+        updated_attrs.update(DatasetUtil.pack_flag_attrs(flag_meanings, flag_masks))
 
         return updated_attrs
 

--- a/obsarray/templater/dataset_util.py
+++ b/obsarray/templater/dataset_util.py
@@ -260,14 +260,32 @@ class DatasetUtil:
         )
 
         # add flag attributes
-        variable.attrs["flag_meanings"] = (
-            str(meanings)[1:-1].replace("'", "").replace(",", "")
-        )
-        variable.attrs["flag_masks"] = str([2 ** i for i in range(0, n_masks)])[1:-1]
+        variable.attrs.update(DatasetUtil.return_flag_attrs(meanings))
 
         # todo - make sure flags can't have units
 
         return variable
+
+    @staticmethod
+    def return_flag_attrs(flag_meanings: List[str]) -> dict:
+        """
+        Derive flag related dataset attributes
+
+        :param flag_meanings: flag meanings
+        :return: set of derived flag related attributes
+        """
+
+        n_masks = len(flag_meanings)
+
+        flag_attrs = dict()
+
+        flag_attrs["flag_meanings"] = (
+            str(flag_meanings)[1:-1].replace("'", "").replace(",", "")
+        )
+
+        flag_attrs["flag_masks"] = str([2 ** i for i in range(0, n_masks)])[1:-1]
+
+        return flag_attrs
 
     @staticmethod
     def return_flags_dtype(n_masks: int) -> numpy.typecodes:

--- a/obsarray/templater/dataset_util.py
+++ b/obsarray/templater/dataset_util.py
@@ -5,7 +5,7 @@ Utilities for creating xarray dataset variables in specified forms
 import string
 import xarray
 import numpy
-from typing import Union, Optional, List, Dict
+from typing import Union, Optional, List, Dict, Tuple
 
 
 __author__ = "Sam Hunt <sam.hunt@npl.co.uk>"
@@ -260,14 +260,14 @@ class DatasetUtil:
         )
 
         # add flag attributes
-        variable.attrs.update(DatasetUtil.return_flag_attrs(meanings))
+        variable.attrs.update(DatasetUtil.pack_flag_attrs(meanings))
 
         # todo - make sure flags can't have units
 
         return variable
 
     @staticmethod
-    def return_flag_attrs(flag_meanings: List[str]) -> dict:
+    def pack_flag_attrs(flag_meanings: List[str]) -> dict:
         """
         Derive flag related dataset attributes
 
@@ -286,6 +286,23 @@ class DatasetUtil:
         flag_attrs["flag_masks"] = str([2 ** i for i in range(0, n_masks)])[1:-1]
 
         return flag_attrs
+
+    @staticmethod
+    def unpack_flag_attrs(attrs: dict) -> Tuple[list, list]:
+        """
+        Extract flag related metadata from dataset attributes
+
+        :param attrs: flag variable attributes
+        :return: flag meanings, flag masks lists
+        """
+
+        flag_meanings = (
+            attrs["flag_meanings"].split() if "flag_meanings" in attrs else []
+        )
+        flag_mask = attrs["flag_masks"].split(",") if "flag_masks" in attrs else []
+        flag_mask = [int(m) for m in flag_mask] if flag_mask != [""] else []
+
+        return flag_meanings, flag_mask
 
     @staticmethod
     def return_flags_dtype(n_masks: int) -> numpy.typecodes:

--- a/obsarray/templater/tests/test_dataset_util.py
+++ b/obsarray/templater/tests/test_dataset_util.py
@@ -350,6 +350,14 @@ class TestDatasetUtil(unittest.TestCase):
 
         self.assertDictEqual(test_flag_attrs, exp_flag_attrs)
 
+    def test_pack_flag_attrs_with_mask(self):
+        test_flag_attrs = DatasetUtil.pack_flag_attrs(
+            ["f1", "f2", "f3", "f4"], [1, 4, 8, 16]
+        )
+        exp_flag_attrs = {"flag_meanings": "f1 f2 f3 f4", "flag_masks": "1, 4, 8, 16"}
+
+        self.assertDictEqual(test_flag_attrs, exp_flag_attrs)
+
     def test_unpack_flag_attrs(self):
         flag_attrs = {"flag_meanings": "f1 f2 f3 f4", "flag_masks": "1, 2, 4, 8"}
 
@@ -412,6 +420,28 @@ class TestDatasetUtil(unittest.TestCase):
 
         self.assertRaises(
             ValueError, DatasetUtil.add_flag_meaning_to_attrs, flag_attrs, "f9", np.int8
+        )
+
+    def test_rm_flag_meaning_to_attrs(self):
+        flag_attrs = {"flag_meanings": "f1 f2 f3 f4", "flag_masks": "1, 2, 4, 8"}
+
+        exp_flag_attrs = {
+            "flag_meanings": "f1 f2 f4",
+            "flag_masks": "1, 2, 8",
+        }
+
+        new_attrs = DatasetUtil.rm_flag_meaning_to_attrs(flag_attrs, "f3")
+
+        self.assertDictEqual(exp_flag_attrs, new_attrs)
+
+    def test_rm_flag_meaning_to_attrs_unknown_flag(self):
+        flag_attrs = {
+            "flag_meanings": "f1 f2 f3 f4 f5 f6 f7 f8",
+            "flag_masks": "1, 2, 4, 8, 16, 32, 64, 128",
+        }
+
+        self.assertRaises(
+            ValueError, DatasetUtil.rm_flag_meaning_to_attrs, flag_attrs, "f9"
         )
 
     def test_add_encoding(self):

--- a/obsarray/templater/tests/test_dataset_util.py
+++ b/obsarray/templater/tests/test_dataset_util.py
@@ -422,7 +422,7 @@ class TestDatasetUtil(unittest.TestCase):
             ValueError, DatasetUtil.add_flag_meaning_to_attrs, flag_attrs, "f9", np.int8
         )
 
-    def test_rm_flag_meaning_to_attrs(self):
+    def test_rm_flag_meaning_from_attrs(self):
         flag_attrs = {"flag_meanings": "f1 f2 f3 f4", "flag_masks": "1, 2, 4, 8"}
 
         exp_flag_attrs = {
@@ -430,18 +430,18 @@ class TestDatasetUtil(unittest.TestCase):
             "flag_masks": "1, 2, 8",
         }
 
-        new_attrs = DatasetUtil.rm_flag_meaning_to_attrs(flag_attrs, "f3")
+        new_attrs = DatasetUtil.rm_flag_meaning_from_attrs(flag_attrs, "f3")
 
         self.assertDictEqual(exp_flag_attrs, new_attrs)
 
-    def test_rm_flag_meaning_to_attrs_unknown_flag(self):
+    def test_rm_flag_meaning_from_attrs_unknown_flag(self):
         flag_attrs = {
             "flag_meanings": "f1 f2 f3 f4 f5 f6 f7 f8",
             "flag_masks": "1, 2, 4, 8, 16, 32, 64, 128",
         }
 
         self.assertRaises(
-            ValueError, DatasetUtil.rm_flag_meaning_to_attrs, flag_attrs, "f9"
+            ValueError, DatasetUtil.rm_flag_meaning_from_attrs, flag_attrs, "f9"
         )
 
     def test_add_encoding(self):

--- a/obsarray/templater/tests/test_dataset_util.py
+++ b/obsarray/templater/tests/test_dataset_util.py
@@ -344,6 +344,12 @@ class TestDatasetUtil(unittest.TestCase):
         data_type = DatasetUtil.return_flags_dtype(32)
         self.assertEqual(data_type, np.uint32)
 
+    def test_return_flag_attrs(self):
+        test_flag_attrs = DatasetUtil.return_flag_attrs(["f1", "f2", "f3", "f4"])
+        exp_flag_attrs = {"flag_meanings": "f1 f2 f3 f4", "flag_masks": "1, 2, 4, 8"}
+
+        self.assertDictEqual(test_flag_attrs, exp_flag_attrs)
+
     def test_add_encoding(self):
         vector_variable = DatasetUtil.create_variable([5], np.int8)
         DatasetUtil.add_encoding(

--- a/obsarray/templater/tests/test_dataset_util.py
+++ b/obsarray/templater/tests/test_dataset_util.py
@@ -344,11 +344,44 @@ class TestDatasetUtil(unittest.TestCase):
         data_type = DatasetUtil.return_flags_dtype(32)
         self.assertEqual(data_type, np.uint32)
 
-    def test_return_flag_attrs(self):
-        test_flag_attrs = DatasetUtil.return_flag_attrs(["f1", "f2", "f3", "f4"])
+    def test_pack_flag_attrs(self):
+        test_flag_attrs = DatasetUtil.pack_flag_attrs(["f1", "f2", "f3", "f4"])
         exp_flag_attrs = {"flag_meanings": "f1 f2 f3 f4", "flag_masks": "1, 2, 4, 8"}
 
         self.assertDictEqual(test_flag_attrs, exp_flag_attrs)
+
+    def test_unpack_flag_attrs(self):
+        flag_attrs = {"flag_meanings": "f1 f2 f3 f4", "flag_masks": "1, 2, 4, 8"}
+
+        exp_flag_meanings = ["f1", "f2", "f3", "f4"]
+        exp_flag_masks = [1, 2, 4, 8]
+
+        flag_meanings, flag_masks = DatasetUtil.unpack_flag_attrs(flag_attrs)
+
+        self.assertCountEqual(flag_meanings, exp_flag_meanings)
+        self.assertCountEqual(flag_masks, exp_flag_masks)
+
+    def test_unpack_flag_attrs_emptyflags(self):
+        flag_attrs = {"flag_meanings": "", "flag_masks": ""}
+
+        exp_flag_meanings = []
+        exp_flag_masks = []
+
+        flag_meanings, flag_masks = DatasetUtil.unpack_flag_attrs(flag_attrs)
+
+        self.assertCountEqual(flag_meanings, exp_flag_meanings)
+        self.assertCountEqual(flag_masks, exp_flag_masks)
+
+    def test_unpack_flag_attrs_noflagattrs(self):
+        flag_attrs = {}
+
+        exp_flag_meanings = []
+        exp_flag_masks = []
+
+        flag_meanings, flag_masks = DatasetUtil.unpack_flag_attrs(flag_attrs)
+
+        self.assertCountEqual(flag_meanings, exp_flag_meanings)
+        self.assertCountEqual(flag_masks, exp_flag_masks)
 
     def test_add_encoding(self):
         vector_variable = DatasetUtil.create_variable([5], np.int8)

--- a/obsarray/templater/tests/test_dataset_util.py
+++ b/obsarray/templater/tests/test_dataset_util.py
@@ -383,6 +383,37 @@ class TestDatasetUtil(unittest.TestCase):
         self.assertCountEqual(flag_meanings, exp_flag_meanings)
         self.assertCountEqual(flag_masks, exp_flag_masks)
 
+    def test_add_flag_meaning_to_attrs(self):
+        flag_attrs = {"flag_meanings": "f1 f2 f3 f4", "flag_masks": "1, 2, 4, 8"}
+
+        exp_flag_attrs = {
+            "flag_meanings": "f1 f2 f3 f4 f5",
+            "flag_masks": "1, 2, 4, 8, 16",
+        }
+
+        new_attrs = DatasetUtil.add_flag_meaning_to_attrs(flag_attrs, "f5", np.int32)
+
+        self.assertDictEqual(exp_flag_attrs, new_attrs)
+
+    def test_add_flag_meaning_to_attrs_first(self):
+        flag_attrs = {}
+
+        exp_flag_attrs = {"flag_meanings": "f1", "flag_masks": "1"}
+
+        new_attrs = DatasetUtil.add_flag_meaning_to_attrs(flag_attrs, "f1", np.int32)
+
+        self.assertDictEqual(exp_flag_attrs, new_attrs)
+
+    def test_add_flag_meaning_to_attrs_full(self):
+        flag_attrs = {
+            "flag_meanings": "f1 f2 f3 f4 f5 f6 f7 f8",
+            "flag_masks": "1, 2, 4, 8, 16, 32, 64, 128",
+        }
+
+        self.assertRaises(
+            ValueError, DatasetUtil.add_flag_meaning_to_attrs, flag_attrs, "f9", np.int8
+        )
+
     def test_add_encoding(self):
         vector_variable = DatasetUtil.create_variable([5], np.int8)
         DatasetUtil.add_encoding(

--- a/obsarray/test/test_flag_accessor.py
+++ b/obsarray/test/test_flag_accessor.py
@@ -104,7 +104,7 @@ class TestFlagAccessor(unittest.TestCase):
     def test__is_flag_var_false(self):
         self.assertFalse(self.ds.flag._is_flag_var("temperature"))
 
-    def test__add_unc_var_DataArray(self):
+    def test___setitem___DataArray(self):
         new_flag = xr.DataArray(
             np.zeros(self.ds.precipitation.shape), dims=["x", "y", "time"]
         )
@@ -116,7 +116,7 @@ class TestFlagAccessor(unittest.TestCase):
         np.testing.assert_array_equal(new_flag.values, self.ds.new_flag.values)
 
     @patch("obsarray.flag_accessor.create_var")
-    def test__add_flag_var_tuple(self, mock):
+    def test___setitem___tuple(self, mock):
 
         flag_def = (
             ["x", "y", "time"],
@@ -156,20 +156,20 @@ class TestFlagVariable(unittest.TestCase):
         )
 
     @patch("obsarray.flag_accessor.Flag.__setitem__")
-    def test___setitem__existing_mask(self, m):
+    def test___setitem___existing_mask(self, m):
         self.ds.flag["temperature_flags"]["bad_data"] = True
 
         m.assert_called_with(slice(None, None, None), True)
 
     @patch("obsarray.flag_accessor.Flag.__setitem__")
-    def test___setitem__new_mask(self, m):
+    def test___setitem___new_mask(self, m):
         self.ds.flag["temperature_flags"]["test_flag"] = True
         self.assertEqual(
             self.ds["temperature_flags"].attrs["flag_meanings"][-1], "test_flag"
         )
         m.assert_called_with(slice(None, None, None), True)
 
-    def test___setitem__new_mask_full(self):
+    def test___setitem___new_mask_full(self):
         self.ds["temperature_flags"].attrs["flag_meanings"] = ["test"] * 8
         self.assertRaises(
             ValueError, self.ds.flag["temperature_flags"].__setitem__, "test_flag", True
@@ -217,6 +217,9 @@ class TestFlag(unittest.TestCase):
     def test_expand_slice_first(self):
         sli = self.ds.flag["temperature_flags"]["bad_data"].expand_sli((0,))
         self.assertEqual((0, slice(None), slice(None)), sli)
+
+    def test__setitem__(self):
+        pass
 
 
 if __name__ == "__main__":

--- a/obsarray/test/test_flag_accessor.py
+++ b/obsarray/test/test_flag_accessor.py
@@ -4,6 +4,7 @@ import xarray as xr
 import pandas as pd
 import numpy as np
 import unittest
+from unittest.mock import patch
 import obsarray
 
 
@@ -137,6 +138,31 @@ class TestFlagVariable(unittest.TestCase):
             self.ds.flag["temperature_flags"].keys(),
             ["bad_data", "dubious data"],
         )
+
+
+class TestFlag(unittest.TestCase):
+    def setUp(self):
+        self.ds = create_ds()
+
+    @patch("obsarray.flag_accessor.Flag.expand_sli", return_value="slice")
+    def test___getitem__(self, m):
+        self.assertEqual(
+            self.ds.flag["temperature_flags"]["bad_data"]["in_slice"]._sli, "slice"
+        )
+
+        m.assert_called_with("in_slice")
+
+    def test_expand_slice_full(self):
+        sli = self.ds.flag["temperature_flags"]["bad_data"].expand_sli((1, 1, 1))
+        self.assertEqual((1, 1, 1), sli)
+
+    def test_expand_slice_None(self):
+        sli = self.ds.flag["temperature_flags"]["bad_data"].expand_sli()
+        self.assertEqual((slice(None), slice(None), slice(None)), sli)
+
+    def test_expand_slice_first(self):
+        sli = self.ds.flag["temperature_flags"]["bad_data"].expand_sli((0,))
+        self.assertEqual((0, slice(None), slice(None)), sli)
 
 
 if __name__ == "__main__":

--- a/obsarray/test/test_flag_accessor.py
+++ b/obsarray/test/test_flag_accessor.py
@@ -261,8 +261,43 @@ class TestFlag(unittest.TestCase):
         sli = self.ds.flag["temperature_flags"]["bad_data"].expand_sli((0,))
         self.assertEqual((0, slice(None), slice(None)), sli)
 
-    def test__setitem__(self):
-        pass
+    def test__setitem___False2True(self):
+        self.ds.flag["temperature_flags"]["bad_data"][:, 0, :] = True
+
+        exp_flags = np.array([[[1, 1, 1], [0, 0, 0]], [[1, 1, 1], [0, 0, 0]]])
+
+        np.testing.assert_array_equal(self.ds["temperature_flags"].values, exp_flags)
+
+    def test__setitem___True2False(self):
+
+        self.ds["temperature_flags"].values[:] = 1
+
+        self.ds.flag["temperature_flags"]["bad_data"][:, 1, :] = False
+
+        exp_flags = np.array([[[1, 1, 1], [0, 0, 0]], [[1, 1, 1], [0, 0, 0]]])
+
+        np.testing.assert_array_equal(self.ds["temperature_flags"].values, exp_flags)
+
+    def test__setitem___array(self):
+        self.ds["temperature_flags"].values[:] = np.array(
+            [[[1, 1, 1], [0, 0, 0]], [[1, 1, 1], [0, 0, 0]]]
+        )
+
+        self.ds.flag["temperature_flags"]["bad_data"][:, :, 0] = np.array(
+            [[False, True], [False, True]]
+        )
+
+        exp_flags = np.array([[[0, 1, 1], [1, 0, 0]], [[0, 1, 1], [1, 0, 0]]])
+
+        np.testing.assert_array_equal(self.ds["temperature_flags"].values, exp_flags)
+
+    def test__setitem___array_not_bool(self):
+        self.assertRaises(
+            TypeError,
+            self.ds.flag["temperature_flags"]["bad_data"],
+            slice(None, None, 0),
+            np.array([[0.0, 1.0], [0.0, 1.0]]),
+        )
 
 
 if __name__ == "__main__":

--- a/obsarray/test/test_flag_accessor.py
+++ b/obsarray/test/test_flag_accessor.py
@@ -1,0 +1,51 @@
+"""test_flag_accessor - tests for obsarray.flag_accessor"""
+
+import xarray as xr
+import pandas as pd
+import numpy as np
+import unittest
+import obsarray
+
+
+__author__ = "Sam Hunt <sam.hunt@npl.co.uk>"
+__all__ = []
+
+
+def create_ds():
+    np.random.seed(0)
+    temperature = 15 + 8 * np.random.randn(2, 2, 3)
+    lon = [[-99.83, -99.32], [-99.79, -99.23]]
+    lat = [[42.25, 42.21], [42.63, 42.59]]
+    time = pd.date_range("2014-09-06", periods=3)
+    reference_time = pd.Timestamp("2014-09-05")
+
+    ds = xr.Dataset(
+        data_vars=dict(
+            temperature=(["x", "y", "time"], temperature, {"units": "K"}),
+            temperature_flags=(
+                ["x", "y", "time"],
+                np.zeros(temperature.shape, dtype=np.int8),
+            ),
+        ),
+        coords=dict(
+            lon=(["x", "y"], lon),
+            lat=(["x", "y"], lat),
+            time=time,
+            reference_time=reference_time,
+        ),
+        attrs=dict(description="Weather related data."),
+    )
+
+    return ds
+
+
+class TestFlagAccessor(unittest.TestCase):
+    def setUp(self):
+        self.ds = create_ds()
+
+    def test_method(self):
+        pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/obsarray/test/test_flag_accessor.py
+++ b/obsarray/test/test_flag_accessor.py
@@ -31,7 +31,10 @@ def create_ds():
             temperature_flags=(
                 ["x", "y", "time"],
                 np.zeros(temperature.shape, dtype=np.int8),
-                {"flag_meanings": [], "applicable_vars": ["temperature"]},
+                {
+                    "flag_meanings": ["bad_data", "dubious data"],
+                    "applicable_vars": ["temperature"],
+                },
             ),
         ),
         coords=dict(
@@ -97,6 +100,43 @@ class TestFlagAccessor(unittest.TestCase):
 
     def test__is_flag_var_false(self):
         self.assertFalse(self.ds.flag._is_flag_var("temperature"))
+
+
+class TestFlagVariable(unittest.TestCase):
+    def setUp(self):
+        self.ds = create_ds()
+
+    def test___getitem__(self):
+        self.assertIsInstance(
+            self.ds.flag["temperature_flags"]["bad_data"],
+            obsarray.flag_accessor.Flag,
+        )
+        self.assertEqual(
+            self.ds.flag["temperature_flags"]["bad_data"]._flag_var_name,
+            "temperature_flags",
+        )
+        self.assertEqual(
+            self.ds.flag["temperature_flags"]["bad_data"]._flag_meaning,
+            "bad_data",
+        )
+
+    def test___len__(self):
+        self.assertEqual(len(self.ds.flag["temperature_flags"]), 2)
+
+    def test___iter__(self):
+
+        var_names = []
+        for flag in self.ds.flag["temperature_flags"]:
+            self.assertIsInstance(flag, obsarray.flag_accessor.Flag)
+            var_names.append(flag._flag_meaning)
+
+        self.assertCountEqual(var_names, ["bad_data", "dubious data"])
+
+    def test_keys(self):
+        self.assertCountEqual(
+            self.ds.flag["temperature_flags"].keys(),
+            ["bad_data", "dubious data"],
+        )
 
 
 if __name__ == "__main__":

--- a/obsarray/test/test_flag_accessor.py
+++ b/obsarray/test/test_flag_accessor.py
@@ -155,6 +155,26 @@ class TestFlagVariable(unittest.TestCase):
             "bad_data",
         )
 
+    @patch("obsarray.flag_accessor.Flag.__setitem__")
+    def test___setitem__existing_mask(self, m):
+        self.ds.flag["temperature_flags"]["bad_data"] = True
+
+        m.assert_called_with(slice(None, None, None), True)
+
+    @patch("obsarray.flag_accessor.Flag.__setitem__")
+    def test___setitem__new_mask(self, m):
+        self.ds.flag["temperature_flags"]["test_flag"] = True
+        self.assertEqual(
+            self.ds["temperature_flags"].attrs["flag_meanings"][-1], "test_flag"
+        )
+        m.assert_called_with(slice(None, None, None), True)
+
+    def test___setitem__new_mask_full(self):
+        self.ds["temperature_flags"].attrs["flag_meanings"] = ["test"] * 8
+        self.assertRaises(
+            ValueError, self.ds.flag["temperature_flags"].__setitem__, "test_flag", True
+        )
+
     def test___len__(self):
         self.assertEqual(len(self.ds.flag["temperature_flags"]), 2)
 

--- a/obsarray/test/test_flag_accessor.py
+++ b/obsarray/test/test_flag_accessor.py
@@ -299,6 +299,16 @@ class TestFlag(unittest.TestCase):
             np.array([[0.0, 1.0], [0.0, 1.0]]),
         )
 
+    def test_value(self):
+        self.ds["temperature_flags"].values[:] = np.array(
+            [[[1, 1, 1], [0, 0, 0]], [[1, 1, 1], [0, 0, 0]]]
+        )
+
+        mask = self.ds.flag["temperature_flags"]["bad_data"][:, :, 0].value
+        exp_mask = np.array([[True, False], [True, False]])
+
+        np.testing.assert_array_equal(mask, exp_mask)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/obsarray/test/test_flag_accessor.py
+++ b/obsarray/test/test_flag_accessor.py
@@ -205,6 +205,19 @@ class TestFlagVariable(unittest.TestCase):
 
         mf.assert_called_with(slice(None, None, None), True)
 
+    @patch("obsarray.flag_accessor.Flag.__setitem__")
+    @patch("obsarray.flag_accessor.DatasetUtil.rm_flag_meaning_from_attrs")
+    def test___delitem__(self, mdu, mf):
+        original_attrs = deepcopy(self.ds["temperature_flags"].attrs)
+
+        del self.ds.flag["temperature_flags"]["dubious_data"]
+
+        mdu.assert_called_once_with(original_attrs, "dubious_data")
+
+        self.assertDictEqual(self.ds["temperature_flags"].attrs, {})
+
+        mf.assert_called_with(slice(None, None, None), False)
+
     def test___len__(self):
         self.assertEqual(len(self.ds.flag["temperature_flags"]), 2)
 


### PR DESCRIPTION
Adds xarray dataset accessor for handling flag variables (defined following the [cf conventions](https://cfconventions.org/Data/cf-conventions/cf-conventions-1.10/cf-conventions.html#flags)).

A basic explanation of how to use the interface is defined in docs/content/user/flag_accessor.rst.