### PR TITLE
Amended documentation example code

### DIFF
--- a/docs/content/user/templater.rst
+++ b/docs/content/user/templater.rst
@@ -188,7 +188,7 @@ Populating and writing the dataset
                 "dim": ["x", "y", "time"],
                 "attrs": {
                     "units": "K",
-                    "u_components": ["u_temperature"]
+                    "unc_comps": ["u_temperature"]
                 }
             },
             "u_temperature": {

--- a/docs/content/user/templater.rst
+++ b/docs/content/user/templater.rst
@@ -207,7 +207,9 @@ Populating and writing the dataset
             "quality_flag_time": {
                 "dtype": "flag",
                 "dim": ["time"],
-                "flag_meanings": ["bad", "dubious"]
+                "attributes": {
+                    "flag_meanings": ["bad", "dubious"]
+                }
             },
         }
 


### PR DESCRIPTION
Example defined `flag_meanings` but without an `attribute` parent property. The parent property has been added.

If this is not added line 134 from [`./obsarray/templater/template_util.py`](https://github.com/comet-toolkit/obsarray/blob/f73bc4314bb5f5dca1e7ee619ae4c20527ed1d87/obsarray/templater/template_util.py\#L13) attempts to `.pop` a `None` object.
