### PR TITLE
patch/uint8-deprecation-warning

### DIFF
--- a/obsarray/templater/dataset_util.py
+++ b/obsarray/templater/dataset_util.py
@@ -450,15 +450,15 @@ class DatasetUtil:
         if dtype == numpy.int8:
             return numpy.int8(-127)
         if dtype == numpy.uint8:
-            return numpy.uint8(-1)
+            return numpy.uint8(1)
         elif dtype == numpy.int16:
             return numpy.int16(-32767)
         elif dtype == numpy.uint16:
-            return numpy.uint16(-1)
+            return numpy.uint16(1)
         elif dtype == numpy.int32:
             return numpy.int32(-2147483647)
         elif dtype == numpy.uint32:
-            return numpy.uint32(-1)
+            return numpy.uint32(1)
         elif dtype == numpy.int64:
             return numpy.int64(-9223372036854775806)
         elif dtype == numpy.float32:

--- a/obsarray/unc_accessor.py
+++ b/obsarray/unc_accessor.py
@@ -109,7 +109,7 @@ class Uncertainty:
         # Find dimensions in variable slice
         sli_dims = [
             dim
-            for dim, idx in zip(self._obj.dims.keys(), self._sli)
+            for dim, idx in zip(self._obj.dims.keys(), self._sli)  # Due to hit a FutureDeprecation warning
             if not isinstance(idx, int)
         ]
 


### PR DESCRIPTION
Casting a signed integer to an unsigned type was raising deprecation warnings

Added location for FutureDeprecation warning

Check out this [PR](https://github.com/pydata/xarray/pull/8500/files) for a simple solution to resolve. 