### PR TITLE
10 method to safely rename uncertainty variable

### DIFF
--- a/docs/content/user/unc_accessor.rst
+++ b/docs/content/user/unc_accessor.rst
@@ -181,9 +181,20 @@ A component of uncertainty can be simply be deleted as,
 .. ipython:: python
    :okwarning:
 
-   del ds.unc["temperature"]["u_sys_temperature"]
+   del ds.unc["temperature"]["u_str_temperature"]
 
    # Check uncertainties
    ds.unc["temperature"].keys()
 
+Renaming Variables
+------------------
 
+The storage of uncertainty information is underpinned by variable attributes, which include referencing other variables (for example, which variables are the uncertainties associated with a particular observation variable). Because of this it is important, if renaming uncertainty variables, to use **obsarray**'s renaming functionality. This renames the uncertainty variable and safely updates attribute variable references. This is done as follows:
+
+
+.. ipython:: python
+   :okwarning:
+
+   print(ds.unc["temperature"])
+   ds = ds.unc["temperature"]["u_ran_temperature"].rename("u_noise")
+   print(ds.unc["temperature"])

--- a/obsarray/test/test_unc_accessor.py
+++ b/obsarray/test/test_unc_accessor.py
@@ -528,6 +528,15 @@ class TestUncertainty(unittest.TestCase):
         sli = self.ds.unc["temperature"]["u_ran_temperature"].expand_sli((0,))
         self.assertEqual((0, slice(None), slice(None)), sli)
 
+    def test_rename(self):
+        ds = self.ds.unc["temperature"]["u_ran_temperature"].rename("test")
+        self.assertTrue("test" in ds.keys())
+        self.assertTrue("u_ran_temperature" not in ds.keys())
+        self.assertCountEqual(
+            ds["temperature"].attrs["unc_comps"],
+            ["test", "u_str_temperature", "u_sys_temperature"],
+        )
+
     def test_err_corr(self):
 
         expected_err_corr = [

--- a/obsarray/unc_accessor.py
+++ b/obsarray/unc_accessor.py
@@ -92,6 +92,20 @@ class Uncertainty:
 
         return out_sli
 
+    def rename(self, name) -> xr.Dataset:
+        """
+        Renames uncertainty variable and safely updates variable name references in obs variable metadata
+        :param name: desired name
+        :returns: dataset with safely renamed variable
+        """
+        self._obj = self._obj.rename({self._unc_var_name: name})
+        self._obj[self._var_name].attrs["unc_comps"] = [
+            v.replace(self._unc_var_name, name)
+            for v in self._obj[self._var_name].attrs["unc_comps"]
+        ]
+
+        return self._obj
+
     @property
     def err_corr(self) -> List[Tuple[Union[str, List[str]], BaseErrCorrForm]]:
         """
@@ -105,7 +119,9 @@ class Uncertainty:
         # Find dimensions in variable slice
         sli_dims = [
             dim
-            for dim, idx in zip(self._obj.dims.keys(), self._sli)  # Due to hit a FutureDeprecation warning
+            for dim, idx in zip(
+                self._obj.dims.keys(), self._sli
+            )  # Due to hit a FutureDeprecation warning
             if not isinstance(idx, int)
         ]
 


### PR DESCRIPTION
Adds method to safely rename uncertainty variable and safely updates attribute variable references. Run as

`ds = ds.unc["obs_var"]["old_unc_name"].rename("new_unc_name")`

Closes #10 