### PR TITLE
Renaming of dimensions and variables

### DIFF
--- a/docs/content/user/api.rst
+++ b/docs/content/user/api.rst
@@ -30,6 +30,8 @@ Uncertainty functions
    unc_accessor.UncAccessor.unc_vars
    unc_accessor.UncAccessor.__getitem__
    unc_accessor.UncAccessor.keys
+   unc_accessor.UncAccessor.rename
+   unc_accessor.UncAccessor.rename_dims
    unc_accessor.VariableUncertainty
    unc_accessor.VariableUncertainty.__getitem__
    unc_accessor.VariableUncertainty.__setitem__
@@ -84,3 +86,11 @@ Flag functions
    flag_accessor.Flag.__getitem__
    flag_accessor.Flag.__setitem__
    flag_accessor.Flag.value
+
+Utility functions
+=================
+
+.. autosummary::
+   :toctree: generated/
+
+   utils.append_names

--- a/docs/content/user/unc_accessor.rst
+++ b/docs/content/user/unc_accessor.rst
@@ -186,15 +186,16 @@ A component of uncertainty can be simply be deleted as,
    # Check uncertainties
    ds.unc["temperature"].keys()
 
-Renaming Variables
-------------------
+Renaming Variables and Dimensions
+---------------------------------
 
-The storage of uncertainty information is underpinned by variable attributes, which include referencing other variables (for example, which variables are the uncertainties associated with a particular observation variable). Because of this it is important, if renaming uncertainty variables, to use **obsarray**'s renaming functionality. This renames the uncertainty variable and safely updates attribute variable references. This is done as follows:
+The storage of uncertainty information is underpinned by variable attributes, which include referencing other variables/dimensions (for example, which variables are the uncertainties associated with a particular observation variable). Because of this it is important, if renaming uncertainty variables or dimensions, to use **obsarray**'s renaming functionality. This renames the uncertainty variable or dimension and safely updates attribute variable references. This is done as follows (mirroring the interface to `xarray renaming <https://docs.xarray.dev/en/latest/generated/xarray.Dataset.rename.html>`_):
 
 
 .. ipython:: python
    :okwarning:
 
    print(ds.unc["temperature"])
-   ds = ds.unc["temperature"]["u_ran_temperature"].rename("u_noise")
+   ds = ds.unc.rename({"u_ran_temperature": "u_noise"})
+   ds = ds.unc.rename_dims({"time": "t"})
    print(ds.unc["temperature"])

--- a/obsarray/__init__.py
+++ b/obsarray/__init__.py
@@ -9,6 +9,7 @@ from obsarray.err_corr import err_corr_forms
 from obsarray.templater.template_util import create_ds
 from obsarray.templater.dstemplater import DSTemplater
 from obsarray.templater.dswriter import DSWriter
+from obsarray.utils import append_names
 
 __version__ = get_versions()["version"]
 del get_versions

--- a/obsarray/test/test_unc_accessor.py
+++ b/obsarray/test/test_unc_accessor.py
@@ -34,7 +34,7 @@ def compare_err_corr_form(self, form, exp_form):
     self.assertCountEqual(form._unc_var_name, exp_form._unc_var_name)
 
 
-def create_ds(dim_suffix=""):
+def create_ds(var_suffix="", dim_suffix="", coord_dim_suffix_extra = ""):
     np.random.seed(0)
     temperature = 15 + 8 * np.random.randn(2, 2, 3)
     u_r_temperature = temperature * 0.02
@@ -47,26 +47,26 @@ def create_ds(dim_suffix=""):
     reference_time = pd.Timestamp("2014-09-05")
 
     ds = xr.Dataset(
-        data_vars=dict(
-            temperature=(["x" + dim_suffix, "y" + dim_suffix, "time" + dim_suffix], temperature, {"units": "K"}),
-        ),
-        coords=dict(
-            lon=(["x" + dim_suffix, "y" + dim_suffix], lon),
-            lat=(["x" + dim_suffix, "y" + dim_suffix], lat),
-            time=("time" + dim_suffix, time),
-            reference_time=reference_time,
-        ),
+        data_vars={
+            "temperature" + var_suffix: (["x" + dim_suffix, "y" + dim_suffix, "time" + dim_suffix + coord_dim_suffix_extra], temperature, {"units": "K"}),
+        },
+        coords={
+            "lon" + var_suffix: (["x" + dim_suffix, "y" + dim_suffix], lon),
+            "lat" + var_suffix: (["x" + dim_suffix, "y" + dim_suffix], lat),
+            "time" + var_suffix: ("time" + dim_suffix + coord_dim_suffix_extra, time),
+            "reference_time": reference_time,
+    },
         attrs=dict(description="Weather related data."),
     )
 
-    ds.unc["temperature"]["u_ran_temperature"] = (
-        ["x" + dim_suffix, "y" + dim_suffix, "time" + dim_suffix],
+    ds.unc["temperature" + var_suffix]["u_ran_temperature" + var_suffix] = (
+        ["x" + dim_suffix, "y" + dim_suffix, "time" + dim_suffix + coord_dim_suffix_extra],
         temperature * 0.05,
         {"units": "K", "pdf_shape": "gaussian"},
     )
 
-    ds.unc["temperature"]["u_sys_temperature"] = (
-        ["x" + dim_suffix, "y" + dim_suffix, "time" + dim_suffix],
+    ds.unc["temperature" + var_suffix]["u_sys_temperature" + var_suffix] = (
+        ["x" + dim_suffix, "y" + dim_suffix, "time" + dim_suffix + coord_dim_suffix_extra],
         temperature * 0.03,
         {
             "units": "K",
@@ -82,7 +82,7 @@ def create_ds(dim_suffix=""):
                     "params": [],
                 },
                 {
-                    "dim": "time" + dim_suffix,
+                    "dim": "time" + dim_suffix + coord_dim_suffix_extra,
                     "form": "systematic",
                     "params": [],
                 },
@@ -91,16 +91,16 @@ def create_ds(dim_suffix=""):
         },
     )
 
-    ds.unc["temperature"]["u_str_temperature"] = (
-        ["x" + dim_suffix, "y" + dim_suffix, "time" + dim_suffix],
+    ds.unc["temperature" + var_suffix]["u_str_temperature" + var_suffix] = (
+        ["x" + dim_suffix, "y" + dim_suffix, "time" + dim_suffix + coord_dim_suffix_extra],
         temperature * 0.1,
         {
             "units": "K",
             "err_corr": [
                 {
-                    "dim": ["x" + dim_suffix, "time" + dim_suffix],
+                    "dim": ["x" + dim_suffix, "time" + dim_suffix + coord_dim_suffix_extra],
                     "form": "err_corr_matrix",
-                    "params": ["err_corr_str_temperature"],
+                    "params": ["err_corr_str_temperature" + var_suffix],
                 },
                 {
                     "dim": "y" + dim_suffix,
@@ -112,7 +112,7 @@ def create_ds(dim_suffix=""):
         },
     )
 
-    ds["err_corr_str_temperature"] = (
+    ds["err_corr_str_temperature" + var_suffix] = (
         ["x.time" + dim_suffix, "x.time" + dim_suffix],
         np.ones(
             (
@@ -740,6 +740,15 @@ class TestUncertainty(unittest.TestCase):
         exp_ecm = xr.DataArray(np.ones((12, 12)), dims=["x.y.time", "x.y.time"])
         xr.testing.assert_equal(ecm, exp_ecm)
 
+    def test_rename_vars(self):
+        var_suffix = "_test"
+        input_ds = create_ds()
+
+        ds = input_ds.unc.rename({"temperature": "temperature" + var_suffix, "lon": "lon" + var_suffix, "lat": "lat" + var_suffix, "time": "time" + var_suffix, "u_ran_temperature": "u_ran_temperature"  + var_suffix, "u_str_temperature": "u_str_temperature"  + var_suffix, "u_sys_temperature": "u_sys_temperature"  + var_suffix, "err_corr_str_temperature": "err_corr_str_temperature" + var_suffix})
+
+        exp_ds = create_ds(var_suffix=var_suffix, coord_dim_suffix_extra=var_suffix)
+
+        xr.testing.assert_identical(ds, exp_ds)
 
     def test_rename_dims(self):
         dim_suffix = "_test"

--- a/obsarray/test/test_unc_accessor.py
+++ b/obsarray/test/test_unc_accessor.py
@@ -34,7 +34,7 @@ def compare_err_corr_form(self, form, exp_form):
     self.assertCountEqual(form._unc_var_name, exp_form._unc_var_name)
 
 
-def create_ds(var_suffix="", dim_suffix="", coord_dim_suffix_extra = ""):
+def create_ds(var_suffix="", dim_suffix="", coord_dim_suffix_extra=""):
     np.random.seed(0)
     temperature = 15 + 8 * np.random.randn(2, 2, 3)
     u_r_temperature = temperature * 0.02
@@ -48,25 +48,42 @@ def create_ds(var_suffix="", dim_suffix="", coord_dim_suffix_extra = ""):
 
     ds = xr.Dataset(
         data_vars={
-            "temperature" + var_suffix: (["x" + dim_suffix, "y" + dim_suffix, "time" + dim_suffix + coord_dim_suffix_extra], temperature, {"units": "K"}),
+            "temperature"
+            + var_suffix: (
+                [
+                    "x" + dim_suffix,
+                    "y" + dim_suffix,
+                    "time" + dim_suffix + coord_dim_suffix_extra,
+                ],
+                temperature,
+                {"units": "K"},
+            ),
         },
         coords={
             "lon" + var_suffix: (["x" + dim_suffix, "y" + dim_suffix], lon),
             "lat" + var_suffix: (["x" + dim_suffix, "y" + dim_suffix], lat),
             "time" + var_suffix: ("time" + dim_suffix + coord_dim_suffix_extra, time),
             "reference_time": reference_time,
-    },
+        },
         attrs=dict(description="Weather related data."),
     )
 
     ds.unc["temperature" + var_suffix]["u_ran_temperature" + var_suffix] = (
-        ["x" + dim_suffix, "y" + dim_suffix, "time" + dim_suffix + coord_dim_suffix_extra],
+        [
+            "x" + dim_suffix,
+            "y" + dim_suffix,
+            "time" + dim_suffix + coord_dim_suffix_extra,
+        ],
         temperature * 0.05,
         {"units": "K", "pdf_shape": "gaussian"},
     )
 
     ds.unc["temperature" + var_suffix]["u_sys_temperature" + var_suffix] = (
-        ["x" + dim_suffix, "y" + dim_suffix, "time" + dim_suffix + coord_dim_suffix_extra],
+        [
+            "x" + dim_suffix,
+            "y" + dim_suffix,
+            "time" + dim_suffix + coord_dim_suffix_extra,
+        ],
         temperature * 0.03,
         {
             "units": "K",
@@ -92,13 +109,20 @@ def create_ds(var_suffix="", dim_suffix="", coord_dim_suffix_extra = ""):
     )
 
     ds.unc["temperature" + var_suffix]["u_str_temperature" + var_suffix] = (
-        ["x" + dim_suffix, "y" + dim_suffix, "time" + dim_suffix + coord_dim_suffix_extra],
+        [
+            "x" + dim_suffix,
+            "y" + dim_suffix,
+            "time" + dim_suffix + coord_dim_suffix_extra,
+        ],
         temperature * 0.1,
         {
             "units": "K",
             "err_corr": [
                 {
-                    "dim": ["x" + dim_suffix, "time" + dim_suffix + coord_dim_suffix_extra],
+                    "dim": [
+                        "x" + dim_suffix,
+                        "time" + dim_suffix + coord_dim_suffix_extra,
+                    ],
                     "form": "err_corr_matrix",
                     "params": ["err_corr_str_temperature" + var_suffix],
                 },
@@ -744,7 +768,18 @@ class TestUncertainty(unittest.TestCase):
         var_suffix = "_test"
         input_ds = create_ds()
 
-        ds = input_ds.unc.rename({"temperature": "temperature" + var_suffix, "lon": "lon" + var_suffix, "lat": "lat" + var_suffix, "time": "time" + var_suffix, "u_ran_temperature": "u_ran_temperature"  + var_suffix, "u_str_temperature": "u_str_temperature"  + var_suffix, "u_sys_temperature": "u_sys_temperature"  + var_suffix, "err_corr_str_temperature": "err_corr_str_temperature" + var_suffix})
+        ds = input_ds.unc.rename(
+            {
+                "temperature": "temperature" + var_suffix,
+                "lon": "lon" + var_suffix,
+                "lat": "lat" + var_suffix,
+                "time": "time" + var_suffix,
+                "u_ran_temperature": "u_ran_temperature" + var_suffix,
+                "u_str_temperature": "u_str_temperature" + var_suffix,
+                "u_sys_temperature": "u_sys_temperature" + var_suffix,
+                "err_corr_str_temperature": "err_corr_str_temperature" + var_suffix,
+            }
+        )
 
         exp_ds = create_ds(var_suffix=var_suffix, coord_dim_suffix_extra=var_suffix)
 
@@ -754,7 +789,14 @@ class TestUncertainty(unittest.TestCase):
         dim_suffix = "_test"
         input_ds = create_ds()
 
-        ds = input_ds.unc.rename_dims({"x": "x" + dim_suffix, "y": "y" + dim_suffix, "time": "time" + dim_suffix, "x.time": "x.time_test"})
+        ds = input_ds.unc.rename_dims(
+            {
+                "x": "x" + dim_suffix,
+                "y": "y" + dim_suffix,
+                "time": "time" + dim_suffix,
+                "x.time": "x.time_test",
+            }
+        )
 
         exp_ds = create_ds(dim_suffix=dim_suffix)
 

--- a/obsarray/test/test_utils.py
+++ b/obsarray/test/test_utils.py
@@ -8,45 +8,42 @@ import xarray as xr
 __author__ = "Sam Hunt <sam.hunt@npl.co.uk>"
 __all__ = []
 
+
 def create_test_ds(suffix):
     # define ds variables
     template = {
-        "temperature" + suffix: {
+        "temperature"
+        + suffix: {
             "dtype": np.float32,
             "dim": ["x" + suffix, "y" + suffix, "time" + suffix],
             "attributes": {
                 "units": "K",
-                "unc_comps": ["u_ran_temperature" + suffix, "u_sys_temperature" + suffix]
-            }
-        },
-        "u_ran_temperature" + suffix: {
-            "dtype": np.float32,
-            "dim": ["x" + suffix, "y" + suffix, "time" + suffix],
-            "attributes": {
-                "units": "K",
-                "err_corr": [
-                    {
-                        "dim": "x" + suffix,
-                        "form": "random",
-                        "params": [],
-                        "units": []
-                    },
-                    {
-                        "dim": "y" + suffix,
-                        "form": "random",
-                        "params": [],
-                        "units": []
-                    },
-                    {
-                        "dim": "time" + suffix,
-                        "form": "random",
-                        "params": [],
-                        "units": []
-                    }
-                ]
+                "unc_comps": [
+                    "u_ran_temperature" + suffix,
+                    "u_sys_temperature" + suffix,
+                ],
             },
         },
-        "u_sys_temperature" + suffix: {
+        "u_ran_temperature"
+        + suffix: {
+            "dtype": np.float32,
+            "dim": ["x" + suffix, "y" + suffix, "time" + suffix],
+            "attributes": {
+                "units": "K",
+                "err_corr": [
+                    {"dim": "x" + suffix, "form": "random", "params": [], "units": []},
+                    {"dim": "y" + suffix, "form": "random", "params": [], "units": []},
+                    {
+                        "dim": "time" + suffix,
+                        "form": "random",
+                        "params": [],
+                        "units": [],
+                    },
+                ],
+            },
+        },
+        "u_sys_temperature"
+        + suffix: {
             "dtype": np.float32,
             "dim": ["x" + suffix, "y" + suffix, "time" + suffix],
             "attributes": {
@@ -56,106 +53,86 @@ def create_test_ds(suffix):
                         "dim": "x" + suffix,
                         "form": "systematic",
                         "params": [],
-                        "units": []
+                        "units": [],
                     },
                     {
                         "dim": "y" + suffix,
                         "form": "systematic",
                         "params": [],
-                        "units": []
+                        "units": [],
                     },
                     {
                         "dim": "time" + suffix,
                         "form": "systematic",
                         "params": [],
-                        "units": []
-                    }
-                ]
-            }
+                        "units": [],
+                    },
+                ],
+            },
         },
-        "pressure" + suffix: {
+        "pressure"
+        + suffix: {
             "dtype": np.float32,
             "dim": ["x" + suffix, "y" + suffix, "time" + suffix],
-            "attributes": {
-                "units": "Pa",
-                "unc_comps": ["u_str_pressure" + suffix]
-            }
+            "attributes": {"units": "Pa", "unc_comps": ["u_str_pressure" + suffix]},
         },
-        "u_str_pressure" + suffix: {
+        "u_str_pressure"
+        + suffix: {
             "dtype": np.float32,
             "dim": ["x" + suffix, "y" + suffix, "time" + suffix],
             "attributes": {
                 "units": "Pa",
                 "err_corr": [
-                    {
-                        "dim": "x" + suffix,
-                        "form": "random",
-                        "params": [],
-                        "units": []
-                    },
+                    {"dim": "x" + suffix, "form": "random", "params": [], "units": []},
                     {
                         "dim": "y" + suffix,
                         "form": "err_corr_matrix",
                         "params": "err_corr_str_pressure_y",
-                        "units": []
+                        "units": [],
                     },
                     {
                         "dim": "time" + suffix,
                         "form": "systematic",
                         "params": [],
-                        "units": []
-                    }
-                ]
+                        "units": [],
+                    },
+                ],
             },
         },
-        "err_corr_str_pressure_y" + suffix: {
+        "err_corr_str_pressure_y"
+        + suffix: {
             "dtype": np.float32,
             "dim": ["y" + suffix, "y" + suffix],
             "attributes": {"units": ""},
         },
-        "n_moles" + suffix: {
+        "n_moles"
+        + suffix: {
             "dtype": np.float32,
             "dim": ["x" + suffix, "y" + suffix, "time" + suffix],
-            "attributes": {
-                "units": "",
-                "unc_comps": ["u_ran_n_moles" + suffix]
-            }
+            "attributes": {"units": "", "unc_comps": ["u_ran_n_moles" + suffix]},
         },
-        "u_ran_n_moles" + suffix: {
+        "u_ran_n_moles"
+        + suffix: {
             "dtype": np.float32,
             "dim": ["x" + suffix, "y" + suffix, "time" + suffix],
             "attributes": {
                 "units": "",
                 "err_corr": [
-                    {
-                        "dim": "x" + suffix,
-                        "form": "random",
-                        "params": [],
-                        "units": []
-                    },
-                    {
-                        "dim": "y" + suffix,
-                        "form": "random",
-                        "params": [],
-                        "units": []
-                    },
+                    {"dim": "x" + suffix, "form": "random", "params": [], "units": []},
+                    {"dim": "y" + suffix, "form": "random", "params": [], "units": []},
                     {
                         "dim": "time" + suffix,
                         "form": "random",
                         "params": [],
-                        "units": []
-                    }
-                ]
+                        "units": [],
+                    },
+                ],
             },
         },
     }
 
     # define dim_size_dict to specify size of arrays
-    dim_sizes = {
-        "x" + suffix: 20,
-        "y" + suffix: 30,
-        "time" + suffix: 6
-    }
+    dim_sizes = {"x" + suffix: 20, "y" + suffix: 30, "time" + suffix: 6}
 
     # create dataset template
     ds = create_ds(template, dim_sizes)
@@ -164,9 +141,11 @@ def create_test_ds(suffix):
     ds["temperature" + suffix].values = 293 * np.ones((20, 30, 6))
     ds["u_ran_temperature" + suffix].values = 1 * np.ones((20, 30, 6))
     ds["u_sys_temperature" + suffix].values = 0.4 * np.ones((20, 30, 6))
-    ds["pressure" + suffix].values = 10 ** 5 * np.ones((20, 30, 6))
+    ds["pressure" + suffix].values = 10**5 * np.ones((20, 30, 6))
     ds["u_str_pressure" + suffix].values = 10 * np.ones((20, 30, 6))
-    ds["err_corr_str_pressure_y" + suffix].values = 0.5 * np.ones((30, 30)) + 0.5 * np.eye(30)
+    ds["err_corr_str_pressure_y" + suffix].values = 0.5 * np.ones(
+        (30, 30)
+    ) + 0.5 * np.eye(30)
     ds["n_moles" + suffix].values = 40 * np.ones((20, 30, 6))
     ds["u_ran_n_moles" + suffix].values = 1 * np.ones((20, 30, 6))
 
@@ -174,15 +153,17 @@ def create_test_ds(suffix):
 
     return ds
 
+
 class TestAppendNames(unittest.TestCase):
     def test_append_names(self):
 
-        input_ds = create_test_ds(suffix = "")
+        input_ds = create_test_ds(suffix="")
         ds = append_names(input_ds, "_test")
 
         exp_ds = create_test_ds(suffix="_test")
 
         xr.testing.assert_identical(ds, exp_ds)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/obsarray/test/test_utils.py
+++ b/obsarray/test/test_utils.py
@@ -1,0 +1,188 @@
+"""test_utils - tests for obsarray.utils"""
+
+import unittest
+import numpy as np
+from obsarray import append_names, create_ds
+import xarray as xr
+
+__author__ = "Sam Hunt <sam.hunt@npl.co.uk>"
+__all__ = []
+
+def create_test_ds(suffix):
+    # define ds variables
+    template = {
+        "temperature" + suffix: {
+            "dtype": np.float32,
+            "dim": ["x" + suffix, "y" + suffix, "time" + suffix],
+            "attributes": {
+                "units": "K",
+                "unc_comps": ["u_ran_temperature" + suffix, "u_sys_temperature" + suffix]
+            }
+        },
+        "u_ran_temperature" + suffix: {
+            "dtype": np.float32,
+            "dim": ["x" + suffix, "y" + suffix, "time" + suffix],
+            "attributes": {
+                "units": "K",
+                "err_corr": [
+                    {
+                        "dim": "x" + suffix,
+                        "form": "random",
+                        "params": [],
+                        "units": []
+                    },
+                    {
+                        "dim": "y" + suffix,
+                        "form": "random",
+                        "params": [],
+                        "units": []
+                    },
+                    {
+                        "dim": "time" + suffix,
+                        "form": "random",
+                        "params": [],
+                        "units": []
+                    }
+                ]
+            },
+        },
+        "u_sys_temperature" + suffix: {
+            "dtype": np.float32,
+            "dim": ["x" + suffix, "y" + suffix, "time" + suffix],
+            "attributes": {
+                "units": "K",
+                "err_corr": [
+                    {
+                        "dim": "x" + suffix,
+                        "form": "systematic",
+                        "params": [],
+                        "units": []
+                    },
+                    {
+                        "dim": "y" + suffix,
+                        "form": "systematic",
+                        "params": [],
+                        "units": []
+                    },
+                    {
+                        "dim": "time" + suffix,
+                        "form": "systematic",
+                        "params": [],
+                        "units": []
+                    }
+                ]
+            }
+        },
+        "pressure" + suffix: {
+            "dtype": np.float32,
+            "dim": ["x" + suffix, "y" + suffix, "time" + suffix],
+            "attributes": {
+                "units": "Pa",
+                "unc_comps": ["u_str_pressure" + suffix]
+            }
+        },
+        "u_str_pressure" + suffix: {
+            "dtype": np.float32,
+            "dim": ["x" + suffix, "y" + suffix, "time" + suffix],
+            "attributes": {
+                "units": "Pa",
+                "err_corr": [
+                    {
+                        "dim": "x" + suffix,
+                        "form": "random",
+                        "params": [],
+                        "units": []
+                    },
+                    {
+                        "dim": "y" + suffix,
+                        "form": "err_corr_matrix",
+                        "params": "err_corr_str_pressure_y",
+                        "units": []
+                    },
+                    {
+                        "dim": "time" + suffix,
+                        "form": "systematic",
+                        "params": [],
+                        "units": []
+                    }
+                ]
+            },
+        },
+        "err_corr_str_pressure_y" + suffix: {
+            "dtype": np.float32,
+            "dim": ["y" + suffix, "y" + suffix],
+            "attributes": {"units": ""},
+        },
+        "n_moles" + suffix: {
+            "dtype": np.float32,
+            "dim": ["x" + suffix, "y" + suffix, "time" + suffix],
+            "attributes": {
+                "units": "",
+                "unc_comps": ["u_ran_n_moles" + suffix]
+            }
+        },
+        "u_ran_n_moles" + suffix: {
+            "dtype": np.float32,
+            "dim": ["x" + suffix, "y" + suffix, "time" + suffix],
+            "attributes": {
+                "units": "",
+                "err_corr": [
+                    {
+                        "dim": "x" + suffix,
+                        "form": "random",
+                        "params": [],
+                        "units": []
+                    },
+                    {
+                        "dim": "y" + suffix,
+                        "form": "random",
+                        "params": [],
+                        "units": []
+                    },
+                    {
+                        "dim": "time" + suffix,
+                        "form": "random",
+                        "params": [],
+                        "units": []
+                    }
+                ]
+            },
+        },
+    }
+
+    # define dim_size_dict to specify size of arrays
+    dim_sizes = {
+        "x" + suffix: 20,
+        "y" + suffix: 30,
+        "time" + suffix: 6
+    }
+
+    # create dataset template
+    ds = create_ds(template, dim_sizes)
+
+    # populate with example data
+    ds["temperature" + suffix].values = 293 * np.ones((20, 30, 6))
+    ds["u_ran_temperature" + suffix].values = 1 * np.ones((20, 30, 6))
+    ds["u_sys_temperature" + suffix].values = 0.4 * np.ones((20, 30, 6))
+    ds["pressure" + suffix].values = 10 ** 5 * np.ones((20, 30, 6))
+    ds["u_str_pressure" + suffix].values = 10 * np.ones((20, 30, 6))
+    ds["err_corr_str_pressure_y" + suffix].values = 0.5 * np.ones((30, 30)) + 0.5 * np.eye(30)
+    ds["n_moles" + suffix].values = 40 * np.ones((20, 30, 6))
+    ds["u_ran_n_moles" + suffix].values = 1 * np.ones((20, 30, 6))
+
+    ds.attrs["attr" + suffix] = "val"
+
+    return ds
+
+class TestAppendNames(unittest.TestCase):
+    def test_append_names(self):
+
+        input_ds = create_test_ds(suffix = "")
+        ds = append_names(input_ds, "_test")
+
+        exp_ds = create_test_ds(suffix="_test")
+
+        xr.testing.assert_identical(ds, exp_ds)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/obsarray/unc_accessor.py
+++ b/obsarray/unc_accessor.py
@@ -895,7 +895,6 @@ class UncAccessor(object):
         del self._obj[unc_var]
         self._obj[obs_var].attrs["unc_comps"].remove(unc_var)
 
-
     def rename(self, vars_dict: dict[str, str]) -> T_Dataset:
         """
         Returns a new dataset with renamed variables - safely handling `unc_vars` and related metadata
@@ -905,7 +904,11 @@ class UncAccessor(object):
         """
 
         # handle case that xarray.Dataset.rename renames the dimension associated with a renamed coordinate dimension
-        coord_dim_dict = {str(dim): vars_dict[dim] for dim in self._obj.dims if (dim in self._obj.coords) and (dim in vars_dict.keys())}
+        coord_dim_dict = {
+            str(dim): vars_dict[dim]
+            for dim in self._obj.dims
+            if (dim in self._obj.coords) and (dim in vars_dict.keys())
+        }
         ds = self.rename_dims(coord_dim_dict)
 
         # update metadata where unc_var err corr param to be renamed
@@ -931,8 +934,12 @@ class UncAccessor(object):
                 ds = ds.unc[obs_var_i][unc_var_i].rename(vars_dict[unc_var_i])
 
         # update remaining variable names
-        non_unc_var_names = list(filter(lambda x: x not in self.unc_vars.keys(), self._obj.variables.keys()))
-        var_dict_no_unc = {n: vars_dict[n] for n in non_unc_var_names if n in vars_dict.keys()}
+        non_unc_var_names = list(
+            filter(lambda x: x not in self.unc_vars.keys(), self._obj.variables.keys())
+        )
+        var_dict_no_unc = {
+            n: vars_dict[n] for n in non_unc_var_names if n in vars_dict.keys()
+        }
         ds = ds.rename(var_dict_no_unc)
 
         return ds
@@ -959,7 +966,9 @@ class UncAccessor(object):
                 if (attr[:9] == "err_corr_") and (attr[-4:] == "_dim"):
                     if isinstance(obj[unc_var_name].attrs[attr], str):
                         if obj[unc_var_name].attrs[attr] in dims_dict:
-                            obj[unc_var_name].attrs[attr] = dims_dict[obj[unc_var_name].attrs[attr]]
+                            obj[unc_var_name].attrs[attr] = dims_dict[
+                                obj[unc_var_name].attrs[attr]
+                            ]
 
                     if isinstance(obj[unc_var_name].attrs[attr], list):
                         for i, attr_i in enumerate(obj[unc_var_name].attrs[attr]):
@@ -967,8 +976,6 @@ class UncAccessor(object):
                                 obj[unc_var_name].attrs[attr][i] = dims_dict[attr_i]
 
         return obj
-
-
 
 
 if __name__ == "__main__":

--- a/obsarray/unc_accessor.py
+++ b/obsarray/unc_accessor.py
@@ -900,7 +900,7 @@ class UncAccessor(object):
         """
         Returns a new dataset with renamed variables - safely handling `unc_vars` and related metadata
 
-        :params vars_dict : Dictionary whose keys are current variable names and whose values are the desired names. The desired names must not be the name of an existing dimension or Variable in the Dataset.
+        :param vars_dict: Dictionary whose keys are current variable names and whose values are the desired names. The desired names must not be the name of an existing dimension or Variable in the Dataset.
         :returns: Dataset with renamed variables
         """
 
@@ -941,7 +941,7 @@ class UncAccessor(object):
         """
         Returns a new dataset with renamed dimensions - safely handling `unc_vars` related metadata
 
-        :params dims_dict : Dictionary whose keys are current dimension names and whose values are the desired names. The desired names must not be the name of an existing dimension or Variable in the Dataset.
+        :param dims_dict: Dictionary whose keys are current dimension names and whose values are the desired names. The desired names must not be the name of an existing dimension or Variable in the Dataset.
         :returns: Dataset with renamed dimensions
         """
 

--- a/obsarray/utils.py
+++ b/obsarray/utils.py
@@ -28,12 +28,12 @@ def empty_err_corr_matrix(obs_var: xr.DataArray):
 
 
 def append_names(
-        ds: T_Dataset,
-        suffix: str,
-        skip_vars: bool = False,
-        skip_dims: bool = False,
-        skip_attrs: bool = False
-    ) -> T_Dataset:
+    ds: T_Dataset,
+    suffix: str,
+    skip_vars: bool = False,
+    skip_dims: bool = False,
+    skip_attrs: bool = False,
+) -> T_Dataset:
     """
     Appends a suffix to the names of dataset variables, dimensions, and attributes - safely handling `unc_vars` and associated metadata
 

--- a/obsarray/utils.py
+++ b/obsarray/utils.py
@@ -2,10 +2,10 @@
 
 import numpy as np
 import xarray as xr
-
+from xarray.core.types import T_Dataset
 
 __author__ = "Sam Hunt <sam.hunt@npl.co.uk>"
-__all__ = ["empty_err_corr_matrix"]
+__all__ = ["empty_err_corr_matrix", "append_names"]
 
 
 def empty_err_corr_matrix(obs_var: xr.DataArray):
@@ -25,6 +25,41 @@ def empty_err_corr_matrix(obs_var: xr.DataArray):
     err_corr_matrix = xr.DataArray(np.eye(n_elems), dims=[erc_dim_name, erc_dim_name])
 
     return err_corr_matrix
+
+
+def append_names(
+        ds: T_Dataset,
+        suffix: str,
+        skip_vars: bool = False,
+        skip_dims: bool = False,
+        skip_attrs: bool = False
+    ) -> T_Dataset:
+    """
+    Appends a suffix to the names of dataset variables, dimensions, and attributes - safely handling `unc_vars` and associated metadata
+
+    :param ds: xarray dataset
+    :param suffix: suffix to append to dataset variable, dimension, and attribute names
+    :param skip_vars: (default: `False`) switch to skip applying suffix to variable names
+    :param skip_dims: (default: `False`) switch to skip applying suffix to dimension names
+    :param skip_attrs: (default: `False`) switch to skip applying suffix to variable names
+    :returns: ds with suffix appended to names of variables, dimensions, attributes
+    """
+
+    # update variable names
+    if not skip_vars:
+        var_rename = {var_name: var_name + suffix for var_name in ds.variables.keys()}
+        ds = ds.unc.rename(var_rename)
+
+    # update dimension names
+    if not skip_dims:
+        dim_rename = {dim_name: dim_name + suffix for dim_name in ds.dims.keys()}
+        ds = ds.unc.rename_dims(dim_rename)
+
+    # update attribute names
+    if not skip_attrs:
+        ds.attrs = {key + suffix: value for key, value in ds.attrs.items()}
+
+    return ds
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #21 and #33.

Adds methods (plus tests):

- `obsarray.unc_accessor.UncAccessor.rename`
- `obsarray.unc_accessor.UncAccessor.rename_dims`

Add function (plus tests):

- `obsarray.utils.append_name`

Docs updated according:

- API docs for above functions
- Uncertainty interface section on renaming