### PR TITLE
Update `get_default_fill_value` to be compatible with numpy >=2.0.0

### DIFF
--- a/obsarray/templater/dataset_util.py
+++ b/obsarray/templater/dataset_util.py
@@ -454,15 +454,15 @@ class DatasetUtil:
         if dtype == numpy.int8:
             return numpy.int8(-127)
         if dtype == numpy.uint8:
-            return numpy.uint8(-1)
+            return numpy.iinfo(np.uint8).max
         elif dtype == numpy.int16:
             return numpy.int16(-32767)
         elif dtype == numpy.uint16:
-            return numpy.uint16(-1)
+            return numpy.iinfo(np.uint16).max
         elif dtype == numpy.int32:
             return numpy.int32(-2147483647)
         elif dtype == numpy.uint32:
-            return numpy.uint32(-1)
+            return numpy.iinfo(np.uint32).max
         elif dtype == numpy.int64:
             return numpy.int64(-9223372036854775806)
         elif dtype == numpy.float32:

--- a/obsarray/templater/dataset_util.py
+++ b/obsarray/templater/dataset_util.py
@@ -454,15 +454,15 @@ class DatasetUtil:
         if dtype == numpy.int8:
             return numpy.int8(-127)
         if dtype == numpy.uint8:
-            return numpy.iinfo(np.uint8).max
+            return numpy.iinfo(numpy.uint8).max
         elif dtype == numpy.int16:
             return numpy.int16(-32767)
         elif dtype == numpy.uint16:
-            return numpy.iinfo(np.uint16).max
+            return numpy.iinfo(numpy.uint16).max
         elif dtype == numpy.int32:
             return numpy.int32(-2147483647)
         elif dtype == numpy.uint32:
-            return numpy.iinfo(np.uint32).max
+            return numpy.iinfo(numpy.uint32).max
         elif dtype == numpy.int64:
             return numpy.int64(-9223372036854775806)
         elif dtype == numpy.float32:

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     description="Measurement data handling in Python",
     long_description=read("README.md"),
     packages=find_packages(exclude=("tests",)),
-    install_requires=["comet_maths", "netcdf4==1.6.5", "xarray"],
+    install_requires=["comet_maths", "netcdf4", "xarray"],
     extras_require={
         "dev": [
             "pre-commit",


### PR DESCRIPTION
Silent truncation of values is no longer supported in the newest numpy versions (see [NEP 50](https://numpy.org/neps/nep-0050-scalar-promotion.html) ).

`numpy.uint8(-1)` has therefore been replaced with `numpy.iinfo(numpy.uint8).max` in `get_default_fill_value`, and further related modifications were made. The constraint on `netcdf4` was there to constrain the numpy version to <2.0.0 and is therefore no longer required and has been removed.